### PR TITLE
Enable GeoSPARQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+fuseki_data
+fuseki2_data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 # latest as at 2025-11-06 (missing rocksdbjni jar)
-# ARG DELTA_VERSION=1.1.3-SNAPSHOT
 # ARG DELTA_GIT_HASH=f352db5368cd1d37e26f7c3bd913e02fbd19b86f
+#ARG DELTA_VERSION=2.0.0-SNAPSHOT
+#ARG DELTA_GIT_HASH=3f8efaaf682ea14bc738dd610202956be4970716
 
+#latest min-delta commit 2025-11-06
+#ARG DELTA_GIT_HASH=376007ef5bb4662292509eb07c135a3d27b342ae
+#ARG DELTA_VERSION=1.1.3-SNAPSHOT
+
+#last commit before 1.1.3
+ARG DELTA_GIT_HASH=bb2f9d2f5ea61fed37d5621ec3147dd01e9b0d5b
 ARG DELTA_VERSION=2.0.0-SNAPSHOT
-ARG DELTA_GIT_HASH=3f8efaaf682ea14bc738dd610202956be4970716
 
 #
 # Builder stage
@@ -12,22 +18,29 @@ FROM maven:3.9.11-amazoncorretto-25 AS builder
 
 ARG DELTA_GIT_HASH
 
-WORKDIR /tmp/rdf-delta 
+WORKDIR /tmp/rdf-delta
 
-RUN yum install -y git unzip 
+RUN yum install -y git unzip patch
 
 RUN <<EOF
   # checkout the rdf-delta repo
-  git clone --no-checkout --depth 1 https://github.com/afs/rdf-delta.git .
-  git fetch --depth 1 origin ${DELTA_GIT_HASH}
-  git checkout ${DELTA_GIT_HASH}
+  git init && \
+      git remote add origin https://github.com/afs/rdf-delta.git && \
+      git fetch --depth 1 origin ${DELTA_GIT_HASH}:main && \
+      git checkout main && \
+      git reset --hard ${DELTA_GIT_HASH}
+  # Apply a dependency patch for GeoSPARQL support
+
+  WORKDIR ${JENA_BUILD_DIR}/jena
+  COPY patches/enable-geosparql.diff .
+  RUN patch -p1 < enable-geosparql.diff
 
   # RUN mvn -Drat.skip=true -B verify --file pom.xml
   # Skip tests and skip license check, just package up the code
   mvn -Drat.skip=true -B package -DskipTests --file pom.xml
 
   # unzip the distribution (has the cli commands in it)
-  unzip /tmp/rdf-delta/rdf-delta-dist/target/*.zip 
+  unzip /tmp/rdf-delta/rdf-delta-dist/target/*.zip
 EOF
 
 #
@@ -38,8 +51,8 @@ FROM amazoncorretto:21-alpine
 ARG DELTA_VERSION
 
 RUN <<EOF
-  apk update 
-  apk add --no-cache bash curl libstdc++ 
+  apk update
+  apk add --no-cache bash curl libstdc++
 EOF
 
 WORKDIR /opt/rdf-delta
@@ -48,17 +61,17 @@ COPY config.ttl /opt/rdf-delta/config.ttl
 COPY entrypoint.sh .
 COPY fuseki-entrypoint.sh .
 
-RUN mkdir cli 
+RUN mkdir cli
 
 COPY --from=builder /tmp/rdf-delta/rdf-delta-server/target/rdf-delta-server-${DELTA_VERSION}.jar rdf-delta-server.jar
 COPY --from=builder /tmp/rdf-delta/rdf-delta-fuseki-server/target/rdf-delta-fuseki-server-${DELTA_VERSION}.jar rdf-delta-fuseki-server.jar
 COPY --from=builder /tmp/rdf-delta/rdf-delta-${DELTA_VERSION} cli
 
 # Fuseki data directory for rdf delta
-RUN mkdir -p /fuseki/delta-zones 
+RUN mkdir -p /fuseki/delta-zones
 
 # RDF Delta Patch server data directory
-RUN mkdir -p /opt/rdf-delta/databases 
+RUN mkdir -p /opt/rdf-delta/databases
 
 # Run RDF Delta Patch server
 # See /opt/rdf-delta/fuseki-entrypoint.sh to run Fuseki Main server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,5 @@
-# latest as at 2025-11-06 (missing rocksdbjni jar)
-# ARG DELTA_GIT_HASH=f352db5368cd1d37e26f7c3bd913e02fbd19b86f
-#ARG DELTA_VERSION=2.0.0-SNAPSHOT
-#ARG DELTA_GIT_HASH=3f8efaaf682ea14bc738dd610202956be4970716
-
-#latest min-delta commit 2025-11-06
-#ARG DELTA_GIT_HASH=376007ef5bb4662292509eb07c135a3d27b342ae
-#ARG DELTA_VERSION=1.1.3-SNAPSHOT
-
-#last commit before 1.1.3
-ARG DELTA_GIT_HASH=bb2f9d2f5ea61fed37d5621ec3147dd01e9b0d5b
-ARG DELTA_VERSION=2.0.0-SNAPSHOT
+ARG DELTA_GIT_HASH=f352db5368cd1d37e26f7c3bd913e02fbd19b86f
+ARG DELTA_VERSION=1.1.3-SNAPSHOT
 
 #
 # Builder stage
@@ -36,6 +26,11 @@ COPY patches/enable-geosparql.diff .
 WORKDIR /tmp/rdf-delta/rdf-delta-fuseki-server
 RUN patch --verbose --ignore-whitespace pom.xml < ../enable-geosparql.diff
 WORKDIR /tmp/rdf-delta
+
+# Apply a patch for issue in rocksdb 10.4.2 (explicitly requires native binaries for linux64-musl)
+WORKDIR /tmp/rdf-delta
+COPY patches/rocksdb.diff .
+RUN patch -p1 < rocksdb.diff
 
 # RUN mvn -Drat.skip=true -B verify --file pom.xml
 # Skip tests and skip license check, just package up the code

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,19 +29,20 @@ RUN <<EOF
       git fetch --depth 1 origin ${DELTA_GIT_HASH}:main && \
       git checkout main && \
       git reset --hard ${DELTA_GIT_HASH}
-  # Apply a dependency patch for GeoSPARQL support
+EOF
 
-  WORKDIR ${JENA_BUILD_DIR}/jena
-  COPY patches/enable-geosparql.diff .
-  RUN patch -p1 < enable-geosparql.diff
+# Apply a dependency patch for GeoSPARQL support
+COPY patches/enable-geosparql.diff .
+WORKDIR /tmp/rdf-delta/rdf-delta-fuseki-server
+RUN patch --verbose --ignore-whitespace pom.xml < ../enable-geosparql.diff
+WORKDIR /tmp/rdf-delta
 
-  # RUN mvn -Drat.skip=true -B verify --file pom.xml
-  # Skip tests and skip license check, just package up the code
-  mvn -Drat.skip=true -B package -DskipTests --file pom.xml
+# RUN mvn -Drat.skip=true -B verify --file pom.xml
+# Skip tests and skip license check, just package up the code
+RUN mvn -Drat.skip=true -B package -DskipTests --file pom.xml
 
   # unzip the distribution (has the cli commands in it)
-  unzip /tmp/rdf-delta/rdf-delta-dist/target/*.zip
-EOF
+RUN unzip /tmp/rdf-delta/rdf-delta-dist/target/*.zip
 
 #
 # Final stage

--- a/README.md
+++ b/README.md
@@ -165,3 +165,28 @@ EOF
 
 curl -d query="$query" -d 'output=text' http://localhost:3031/ds
 ```
+
+To test both spatial and text index together, run the following:
+
+```
+query=$(cat << EOF
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX text: <http://jena.apache.org/text#>
+
+SELECT DISTINCT ?address ?literal
+WHERE {
+  BIND("POLYGON ((152.685242 -27.161808, 152.698975 -27.829361, 153.492737 -27.829361, 153.435059 -27.178912, 152.685242 -27.161808))"^^geo:wktLiteral AS ?polygon)
+  ?address geo:hasGeometry / geo:asWKT ?point ;
+           rdfs:label ?addressLabel .
+  FILTER(geof:sfWithin(?point, ?polygon))
+  (?address ?score ?literal) text:query ( "Drive" "highlight:" ) .
+}
+# returns
+# 1<https://linked.data.gov.au/dataset/qld-addr/address/65cb1e52-fc1d-5dee-a2d2-ea7882d12c7e> "32 Barbaralla ↦Drive↤, Springwood, Queensland, Australia"@en
+EOF
+)
+
+curl -d query="$query" -d 'output=text' http://localhost:3030/ds
+```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ task up
 
 # Load the example data to RDF Delta server
 task load
+
+# restart to reload the indexes
+task restart
 ```
 
 You will now have an RDF Delta server with the initial data loaded and two
@@ -116,7 +119,11 @@ Then run `docker compose up -d --build`.
 
 ## Querying the fuseki instances with SPARQL
 
-There is no UI included in the rdf-delta-fuseki-server, so querying is done using curl:
+To easily test a few queries, run `task query`.
+
+Make sure the indexes are up to date by restarting the fuseki servers after the data was loaded.
+
+There is no UI included in the rdf-delta-fuseki-server, so querying manually is done using curl:
 
 ```
 query=$(cat << EOF
@@ -134,6 +141,27 @@ WHERE {
 EOF
 )
 
+
+curl -d query="$query" -d 'output=text' http://localhost:3030/ds
+```
+
+If this returns all 4 addresses in the test dataset, the spatial index is working.
+
+To test the Lucene text index, run the following:
+
+```
+query=$(cat << EOF
+PREFIX text: <http://jena.apache.org/text#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?uri ?label
+WHERE {
+  ?uri text:query 'Queensland' ;
+       rdfs:label ?label .
+}
+LIMIT 5
+# returns all 4 addresses in the test dataset
+EOF
+)
 
 curl -d query="$query" -d 'output=text' http://localhost:3031/ds
 ```

--- a/README.md
+++ b/README.md
@@ -115,3 +115,25 @@ Then run `docker compose up -d --build`.
 
 
 ## Querying the fuseki instances with SPARQL
+
+There is no UI included in the rdf-delta-fuseki-server, so querying is done using curl:
+
+```
+query=$(cat << EOF
+PREFIX addr:    <https://linked.data.gov.au/def/addr/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+
+SELECT DISTINCT ?address
+WHERE {
+  ?address a addr:Address .
+  <https://example.org/australia> geo:sfContains ?address .
+}
+
+# returns all 4 addresses in the test dataset
+EOF
+)
+
+
+curl -d query="$query" -d 'output=text' http://localhost:3031/ds
+```

--- a/README.md
+++ b/README.md
@@ -103,4 +103,15 @@ curl -s -X POST http://172.19.0.1:1066/ds \
   -H "Content-Type: application/rdf-patch"
 ```
 
-# Querying the fuseki instances with SPARQL
+## Rebuilding cached images
+
+To rebuild the images from scratch, you may need to delete any cached images (e.g., if the enable-geosparql.diff patch has changed, docker may not pick this up):
+
+```
+docker rmi -f $(docker images -aq)
+```
+
+Then run `docker compose up -d --build`.
+
+
+## Querying the fuseki instances with SPARQL

--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ curl -s -X POST http://172.19.0.1:1066/ds \
   -H "Content-Type: application/rdf-patch"
 ```
 
+# Querying the fuseki instances with SPARQL

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,10 @@ tasks:
     desc: start delta server and 2 fuseki servers as docker compose services
     cmd: docker compose up -d --build
 
+  restart:
+    desc: Restart both fuseki servers
+    cmd: docker compose restart fuseki1 fuseki2
+
   load:
     desc: Load data.trig as a patch update
     cmd: uv run load_patch.py
@@ -22,4 +26,3 @@ tasks:
   down:
     desc: down the docker services
     cmd: docker compose down
-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,11 +9,15 @@ tasks:
 
   up:
     desc: start delta server and 2 fuseki servers as docker compose services
-    cmd: docker compose up -d
+    cmd: docker compose up -d --build
 
   load:
     desc: Load data.trig as a patch update
     cmd: uv run load_patch.py
+
+  query:
+    desc: Execute a set of queries against the databases
+    cmd: uv run query.py
 
   down:
     desc: down the docker services

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,8 @@ services:
       - 3030:3030
     networks:
       - delta
+    volumes:
+      - ./fuseki_data:/fuseki
     command: ["/bin/bash", "-c", "/opt/rdf-delta/fuseki-entrypoint.sh"]
     depends_on:
       delta:
@@ -31,6 +33,8 @@ services:
       - 3031:3030
     networks:
       - delta
+    volumes:
+      - ./fuseki2_data:/fuseki
     command: ["/bin/bash", "-c", "/opt/rdf-delta/fuseki-entrypoint.sh"]
     depends_on:
       delta:

--- a/config.ttl
+++ b/config.ttl
@@ -29,7 +29,7 @@
     delta:patchlog                     "ds";
     delta:zone                         "/fuseki/delta-zones";
     delta:storage                      "external";
-    delta:dataset                      :geosparql_dataset ;
+    delta:dataset                      :text_dataset ;
 .
 
 :geosparql_dataset
@@ -43,12 +43,12 @@
     geosparql:srsUri                   <http://www.opengis.net/def/crs/OGC/1.3/CRS84> ;
     geosparql:indexSizes               "-1,-1,-1" ;
     geosparql:indexExpires             "5000,5000,5000" ;
-    geosparql:dataset                  :text_dataset ;
+    geosparql:dataset                  :tdb_dataset_readwrite ;
 .
 
 :text_dataset
     rdf:type                            text:TextDataset ;
-    text:dataset                       :tdb_dataset_readwrite ;
+    text:dataset                       :geosparql_dataset ;
     text:index                         :lucene_index ;
 .
 
@@ -64,12 +64,14 @@
 
 :lucene_index
     rdf:type                           text:TextIndexLucene ;
-    text:directory                     "/fuseki/databases/ds/lucene" ;
+    text:directory                     <file:/fuseki/databases/ds/text_index> ;
     text:entityMap                     :entity_map ;
     text:storeValues                   true ;
     text:analyzer [
         rdf:type text:StandardAnalyzer
     ] ;
+    text:queryAnalyzer [ a text:StandardAnalyzer ] ;
+    text:queryParser text:QueryParser ;
     text:multilingualSupport           true ;
     text:propLists (
         [
@@ -96,4 +98,3 @@
         [ text:field "sdo-description" ; text:predicate sdo:description ]
     ) ;
 .
-

--- a/config.ttl
+++ b/config.ttl
@@ -1,87 +1,99 @@
-@prefix :        <#> .
-@prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
-@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix delta:   <http://jena.apache.org/rdf-delta#> .
-@prefix fuseki:  <http://jena.apache.org/fuseki#> .
-@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix tdb2:    <http://jena.apache.org/2016/tdb#> .
-@prefix text:    <http://jena.apache.org/text#> .
-@prefix sdo:     <https://schema.org/> .
+@prefix :          <#> .
+@prefix delta:     <http://jena.apache.org/rdf-delta#> .
+@prefix ex:        <https://example.org/> .
+@prefix fuseki:    <http://jena.apache.org/fuseki#> .
 @prefix geosparql: <http://jena.apache.org/geosparql#> .
+@prefix ja:        <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdf:       <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo:       <https://schema.org> .
+@prefix tdb2:      <http://jena.apache.org/2016/tdb#> .
+@prefix text:      <http://jena.apache.org/text#> .
 
-text:TextDataset  rdfs:subClassOf  ja:RDFDataset .
-geosparql:geosparqlDataset  rdfs:subClassOf  ja:RDFDataset .
-geosparql:geosparqlDataset  rdfs:subClassOf  ja:Object .
-tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
-
-[] a fuseki:Server .
-
-:service_tdb_all
-    a                                  fuseki:Service;
-    fuseki:dataset                     :delta_dataset;
+:service
+    rdf:type                           fuseki:Service ;
     fuseki:name                        "ds" ;
-    rdfs:label                         "TDB2 Dataset";
-    fuseki:serviceQuery                "query", "" , "sparql" ;
+    fuseki:serviceQuery                "sparql" ;
+    fuseki:serviceQuery                "query" ;
     fuseki:serviceUpdate               "update" ;
     fuseki:serviceUpload               "upload" ;
     fuseki:serviceReadWriteGraphStore  "data" ;
     fuseki:serviceReadGraphStore       "get" ;
+    fuseki:dataset                     :delta_dataset ;
 .
 
+
 :delta_dataset
-    a              delta:DeltaDataset ;
-    delta:changes  "http://delta:1066" ;
-    delta:patchlog "ds";
-    delta:zone     "/fuseki/delta-zones";
-    delta:storage  "external";
-    delta:dataset  :text_dataset ;
+    rdf:type                           delta:DeltaDataset ;
+    delta:changes                      "http://delta:1066" ;
+    delta:patchlog                     "ds";
+    delta:zone                         "/fuseki/delta-zones";
+    delta:storage                      "external";
+    delta:dataset                      :geosparql_dataset ;
+.
+
+:geosparql_dataset
+    rdf:type                           geosparql:geosparqlDataset ;
+    geosparql:spatialIndexFile         "/fuseki/databases/ds/spatial.index" ;
+    geosparql:inference                false ;
+    geosparql:queryRewrite             true ;
+    geosparql:applyDefaultGeometry     true ;
+    geosparql:indexEnabled             true ;
+    geosparql:validateGeometryLiterals false ;
+    geosparql:srsUri                   <http://www.opengis.net/def/crs/OGC/1.3/CRS84> ;
+    geosparql:indexSizes               "-1,-1,-1" ;
+    geosparql:indexExpires             "5000,5000,5000" ;
+    geosparql:dataset                  :text_dataset ;
 .
 
 :text_dataset
-    a             text:TextDataset ;
-    text:dataset  :spatial_dataset ;
-    text:index    :indexLucene ;
+    rdf:type                            text:TextDataset ;
+    text:dataset                       :tdb_dataset_readwrite ;
+    text:index                         :lucene_index ;
 .
-
-:spatial_dataset a geosparql:geosparqlDataset ;
-  geosparql:spatialIndexFile "/fuseki/databases/ds/spatial.index";
-
-  # some GeoSPARQL settings. See https://jena.apache.org/documentation/geosparql/geosparql-fuseki.html
-  geosparql:inference            true ; # GeoSPARQL RDFS schema and inferencing (adds additional statements to the dataset)
-  geosparql:queryRewrite         true ; # Simplifies queries, relies on applyDefaultGeometry
-  geosparql:applyDefaultGeometry true ; # Makes the dataset less dependent on one serialization. Adds additional geo:hasSerialization statements to the dataset
-  geosparql:indexEnabled         true ; # Enable caching of re-usable data to improve query performance
-  geosparql:validateGeometryLiterals true ; # Logs warnings when adding invalid geometry
-
-  # 3 item lists: [Geometry Literal, Geometry Transform, Query Rewrite]
-  geosparql:indexSizes           "-1,-1,-1" ;       # Default - unlimited.
-  geosparql:indexExpires         "5000,5000,5000" ; # Default - time in milliseconds.
-
-  geosparql:dataset :tdb_dataset_readwrite .
 
 :tdb_dataset_readwrite
-    a                       tdb2:DatasetTDB2;
-    tdb2:location           "/fuseki/databases/ds" ;
-    tdb2:unionDefaultGraph  true ;
+    rdf:type                           tdb2:DatasetTDB2 ;
+    tdb2:unionDefaultGraph             true ;
+    tdb2:location                      "/fuseki/databases/ds" ;
+    ja:context [
+      ja:cxtName "arq:queryTimeout" ;
+      ja:cxtValue "5000,60000"
+    ] ;
 .
 
-:indexLucene
-    a                 text:TextIndexLucene ;
-    text:directory <file:/fuseki/databases/ds/text_index> ;
-    text:entityMap    :entMap ;
-    text:analyzer     [ a text:StandardAnalyzer ] ;
-    text:storeValues  true ;
-    text:queryAnalyzer [ a text:StandardAnalyzer ] ;
-    text:queryParser text:QueryParser ;
-    text:multilingualSupport true
+:lucene_index
+    rdf:type                           text:TextIndexLucene ;
+    text:directory                     "/fuseki/databases/ds/lucene" ;
+    text:entityMap                     :entity_map ;
+    text:storeValues                   true ;
+    text:analyzer [
+        rdf:type text:StandardAnalyzer
+    ] ;
+    text:multilingualSupport           true ;
+    text:propLists (
+        [
+            text:propListProp ex:allprops ;
+            text:props (
+                rdfs:label
+                sdo:name
+                sdo:description
+            ) ;
+        ]
+    ) ;
 .
 
-:entMap
-    a text:EntityMap ;
-    text:defaultField  "name" ;
-    text:entityField   "uri" ;
-    text:uidField      "uid" ;
-    text:langField     "lang" ;
-    text:graphField    "graph" ;
-    text:map ([ text:field "name" ; text:predicate sdo:name ])
+:entity_map
+    rdf:type                           text:EntityMap ;
+    text:defaultField                  "rdfs-label" ;
+    text:entityField                   "uri" ;
+    text:uidField                      "uid" ;
+    text:langField                     "lang" ;
+    text:graphField                    "graph" ;
+    text:map (
+        [ text:field "rdfs-label" ;      text:predicate rdfs:label ]
+        [ text:field "sdo-name" ;        text:predicate sdo:name ]
+        [ text:field "sdo-description" ; text:predicate sdo:description ]
+    ) ;
 .
+

--- a/config.ttl
+++ b/config.ttl
@@ -1,10 +1,18 @@
 @prefix :        <#> .
+@prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix delta:   <http://jena.apache.org/rdf-delta#> .
 @prefix fuseki:  <http://jena.apache.org/fuseki#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix tdb2:    <http://jena.apache.org/2016/tdb#> .
 @prefix text:    <http://jena.apache.org/text#> .
 @prefix sdo:     <https://schema.org/> .
+@prefix geosparql: <http://jena.apache.org/geosparql#> .
+
+text:TextDataset  rdfs:subClassOf  ja:RDFDataset .
+geosparql:geosparqlDataset  rdfs:subClassOf  ja:RDFDataset .
+geosparql:geosparqlDataset  rdfs:subClassOf  ja:Object .
+tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
 
 [] a fuseki:Server .
 
@@ -13,10 +21,10 @@
     fuseki:dataset                     :delta_dataset;
     fuseki:name                        "ds" ;
     rdfs:label                         "TDB2 Dataset";
-    fuseki:serviceQuery                "query" ;
+    fuseki:serviceQuery                "query", "" , "sparql" ;
     fuseki:serviceUpdate               "update" ;
     fuseki:serviceUpload               "upload" ;
-    fuseki:serviceReadWriteGraphStore  "data" ;     
+    fuseki:serviceReadWriteGraphStore  "data" ;
     fuseki:serviceReadGraphStore       "get" ;
 .
 
@@ -31,9 +39,25 @@
 
 :text_dataset
     a             text:TextDataset ;
-    text:dataset  :tdb_dataset_readwrite ;
+    text:dataset  :spatial_dataset ;
     text:index    :indexLucene ;
 .
+
+:spatial_dataset a geosparql:geosparqlDataset ;
+  geosparql:spatialIndexFile "/fuseki/databases/ds/spatial.index";
+
+  # some GeoSPARQL settings. See https://jena.apache.org/documentation/geosparql/geosparql-fuseki.html
+  geosparql:inference            true ; # GeoSPARQL RDFS schema and inferencing (adds additional statements to the dataset)
+  geosparql:queryRewrite         true ; # Simplifies queries, relies on applyDefaultGeometry
+  geosparql:applyDefaultGeometry true ; # Makes the dataset less dependent on one serialization. Adds additional geo:hasSerialization statements to the dataset
+  geosparql:indexEnabled         true ; # Enable caching of re-usable data to improve query performance
+  geosparql:validateGeometryLiterals true ; # Logs warnings when adding invalid geometry
+
+  # 3 item lists: [Geometry Literal, Geometry Transform, Query Rewrite]
+  geosparql:indexSizes           "-1,-1,-1" ;       # Default - unlimited.
+  geosparql:indexExpires         "5000,5000,5000" ; # Default - time in milliseconds.
+
+  geosparql:dataset :tdb_dataset_readwrite .
 
 :tdb_dataset_readwrite
     a                       tdb2:DatasetTDB2;
@@ -43,10 +67,13 @@
 
 :indexLucene
     a                 text:TextIndexLucene ;
-    text:directory    "/fuseki/databases/ds" ;
+    text:directory <file:/fuseki/databases/ds/text_index> ;
     text:entityMap    :entMap ;
     text:analyzer     [ a text:StandardAnalyzer ] ;
     text:storeValues  true ;
+    text:queryAnalyzer [ a text:StandardAnalyzer ] ;
+    text:queryParser text:QueryParser ;
+    text:multilingualSupport true
 .
 
 :entMap

--- a/data.trig
+++ b/data.trig
@@ -1,10 +1,59 @@
 @prefix ex: <https://example.org/> .
 @prefix sdo: <https://schema.org/> .
+PREFIX addr:    <https://linked.data.gov.au/def/addr/>
+PREFIX geo:     <http://www.opengis.net/ont/geosparql#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema:  <https://schema.org/>
+PREFIX dbo:     <http://dbpedia.org/ontology/>
 
 ex:graph {
-  ex:a 
+  ex:a
     a sdo:Thing ;
     sdo:name "a thing" ;
     sdo:description "test data to submit as a patch" ;
   .
+  <https://example.org/australia_boundingbox>
+        a geo:Geometry;
+        geo:asWKT "POLYGON((112.76 -10.23, 155.48 -10.23, 155.48 -44.28, 112.76 -44.28, 112.76 -10.23))"^^geo:wktLiteral .
+
+  <https://example.org/australia>
+          a                geo:Feature, dbo:Country;
+          rdfs:label       "A broad bounding box of Australia for testing purposes"@en;
+          geo:hasGeometry <https://example.org/australia_boundingbox> .
+
+  <https://linked.data.gov.au/dataset/qld-addr/geocode/891721>
+          a          geo:Geometry;
+          geo:asWKT  "POINT (151.82963099 -27.47602461)"^^geo:wktLiteral .
+
+  <https://linked.data.gov.au/dataset/qld-addr/address/2fd46078-88c0-5f30-b43e-d2908d9445b6>
+          a                geo:Feature, addr:Address;
+          rdfs:label       "10 Emmanulla Drive, Kingsthorpe, Queensland, Australia"@en;
+          geo:hasGeometry  <https://linked.data.gov.au/dataset/qld-addr/geocode/891721> .
+
+  <https://linked.data.gov.au/dataset/qld-addr/geocode/550300>
+          a          geo:Geometry;
+          geo:asWKT  "POINT (153.13401606 -27.62096167)"^^geo:wktLiteral .
+
+  <https://linked.data.gov.au/dataset/qld-addr/address/65cb1e52-fc1d-5dee-a2d2-ea7882d12c7e>
+          a                geo:Feature, addr:Address;
+          rdfs:label       "32 Barbaralla Drive, Springwood, Queensland, Australia"@en;
+          geo:hasGeometry  <https://linked.data.gov.au/dataset/qld-addr/geocode/550300> .
+
+  <https://linked.data.gov.au/dataset/qld-addr/geocode/1070138>
+          a          geo:Geometry;
+          geo:asWKT  "POINT (153.02902944 -27.52955817)"^^geo:wktLiteral .
+
+  <https://linked.data.gov.au/dataset/qld-addr/address/beb30200-2988-5c0a-942b-36cd2138805a>
+          a                geo:Feature, addr:Address;
+          rdfs:label       "32 Woodlea Street, Moorooka, Queensland, Australia"@en;
+          geo:hasGeometry  <https://linked.data.gov.au/dataset/qld-addr/geocode/1070138> .
+
+  <https://linked.data.gov.au/dataset/qld-addr/geocode/2816204>
+          a          geo:Geometry;
+          geo:asWKT  "POINT (153.33534399 -27.85467408)"^^geo:wktLiteral .
+
+  <https://linked.data.gov.au/dataset/qld-addr/address/7036d80a-ecb6-5ec9-86f0-5e5135934e04>
+          a                geo:Feature, addr:Address;
+          rdfs:label       "Unit 3506/4 Oaky Creek Road, Coomera, Queensland, Australia"@en;
+          geo:hasGeometry  <https://linked.data.gov.au/dataset/qld-addr/geocode/2816204> .
 }

--- a/data.trig
+++ b/data.trig
@@ -1,10 +1,9 @@
-@prefix ex: <https://example.org/> .
-@prefix sdo: <https://schema.org/> .
-PREFIX addr:    <https://linked.data.gov.au/def/addr/>
-PREFIX geo:     <http://www.opengis.net/ont/geosparql#>
-PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX schema:  <https://schema.org/>
-PREFIX dbo:     <http://dbpedia.org/ontology/>
+@prefix addr:    <https://linked.data.gov.au/def/addr/> .
+@prefix dbo:     <http://dbpedia.org/ontology/> .
+@prefix ex:      <https://example.org/> .
+@prefix geo:     <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo:     <https://schema.org/> .
 
 ex:graph {
   ex:a

--- a/patches/enable-geosparql.diff
+++ b/patches/enable-geosparql.diff
@@ -1,0 +1,126 @@
+diff --git a/rdf-delta-fuseki-server/pom.xml b/rdf-delta-fuseki-server/pom.xml
+index ddbd0a15..76857451 100644
+--- a/rdf-delta-fuseki-server/pom.xml
++++ b/rdf-delta-fuseki-server/pom.xml
+@@ -3,15 +3,15 @@
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+-
++
+        http://www.apache.org/licenses/LICENSE-2.0
+-
++
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-
++
+    See the NOTICE file distributed with this work for additional
+    information regarding copyright ownership.
+ -->
+@@ -28,7 +28,7 @@
+     <groupId>org.seaborne.rdf-delta</groupId>
+     <artifactId>rdf-delta</artifactId>
+     <version>2.0.0-SNAPSHOT</version>
+-  </parent>
++  </parent>
+
+   <properties>
+     <automatic.module.name>org.seaborne.rdf_delta.fuseki_server</automatic.module.name>
+@@ -40,13 +40,13 @@
+       <groupId>org.seaborne.rdf-delta</groupId>
+       <artifactId>rdf-delta-fuseki</artifactId>
+       <version>2.0.0-SNAPSHOT</version>
+-    </dependency>
+-
++    </dependency>
++
+     <dependency>
+       <groupId>org.seaborne.rdf-delta</groupId>
+       <artifactId>rdf-delta-client</artifactId>
+       <version>2.0.0-SNAPSHOT</version>
+-    </dependency>
++    </dependency>
+
+     <dependency>
+       <groupId>org.apache.jena</groupId>
+@@ -64,6 +64,13 @@
+       <artifactId>jena-text</artifactId>
+     </dependency>
+
++
++    <dependency>
++      <groupId>org.apache.jena</groupId>
++      <artifactId>jena-geosparql</artifactId>
++      <version>5.5.0</version>
++    </dependency>
++
+   </dependencies>
+
+   <build>
+@@ -94,7 +101,7 @@
+           </execution>
+         </executions>
+       </plugin>
+-
++
+       <!-- Shaded uber jar -->
+       <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+diff --git a/rdf-delta-fuseki/pom.xml b/rdf-delta-fuseki/pom.xml
+index 3c5de6f0..ce90c1c3 100644
+--- a/rdf-delta-fuseki/pom.xml
++++ b/rdf-delta-fuseki/pom.xml
+@@ -3,15 +3,15 @@
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+-
++
+        http://www.apache.org/licenses/LICENSE-2.0
+-
++
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-
++
+    See the NOTICE file distributed with this work for additional
+    information regarding copyright ownership.
+ -->
+@@ -28,7 +28,7 @@
+     <groupId>org.seaborne.rdf-delta</groupId>
+     <artifactId>rdf-delta</artifactId>
+     <version>2.0.0-SNAPSHOT</version>
+-  </parent>
++  </parent>
+
+   <properties>
+     <automatic.module.name>org.seaborne.rdf_delta.fuseki</automatic.module.name>
+@@ -38,7 +38,7 @@
+
+     <dependency>
+       <groupId>org.seaborne.rdf-delta</groupId>
+-      <artifactId>rdf-delta-client</artifactId>
++      <artifactId>rdf-delta-client</artifactId>
+       <version>2.0.0-SNAPSHOT</version>
+     </dependency>
+
+@@ -53,6 +53,12 @@
+       <scope>test</scope>
+     </dependency>
+
++    <dependency>
++      <groupId>org.apache.jena</groupId>
++      <artifactId>jena-geosparql</artifactId>
++      <version>5.5.0</version>
++    </dependency>
++
+   </dependencies>
+
+ </project>

--- a/patches/enable-geosparql.diff
+++ b/patches/enable-geosparql.diff
@@ -1,5 +1,5 @@
 diff --git a/rdf-delta-fuseki-server/pom.xml b/rdf-delta-fuseki-server/pom.xml
-index ddbd0a15..76857451 100644
+index ddbd0a15..f1dc71c8 100644
 --- a/rdf-delta-fuseki-server/pom.xml
 +++ b/rdf-delta-fuseki-server/pom.xml
 @@ -3,15 +3,15 @@
@@ -30,7 +30,7 @@ index ddbd0a15..76857451 100644
 
    <properties>
      <automatic.module.name>org.seaborne.rdf_delta.fuseki_server</automatic.module.name>
-@@ -40,13 +40,13 @@
+@@ -40,17 +40,17 @@
        <groupId>org.seaborne.rdf-delta</groupId>
        <artifactId>rdf-delta-fuseki</artifactId>
        <version>2.0.0-SNAPSHOT</version>
@@ -47,6 +47,11 @@ index ddbd0a15..76857451 100644
 
      <dependency>
        <groupId>org.apache.jena</groupId>
+-      <artifactId>jena-fuseki-main</artifactId>
++      <artifactId>jena-fuseki-server</artifactId>
+     </dependency>
+
+     <dependency>
 @@ -64,6 +64,13 @@
        <artifactId>jena-text</artifactId>
      </dependency>
@@ -71,7 +76,7 @@ index ddbd0a15..76857451 100644
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
 diff --git a/rdf-delta-fuseki/pom.xml b/rdf-delta-fuseki/pom.xml
-index 3c5de6f0..ce90c1c3 100644
+index 3c5de6f0..fbad3da2 100644
 --- a/rdf-delta-fuseki/pom.xml
 +++ b/rdf-delta-fuseki/pom.xml
 @@ -3,15 +3,15 @@
@@ -102,7 +107,7 @@ index 3c5de6f0..ce90c1c3 100644
 
    <properties>
      <automatic.module.name>org.seaborne.rdf_delta.fuseki</automatic.module.name>
-@@ -38,7 +38,7 @@
+@@ -38,13 +38,13 @@
 
      <dependency>
        <groupId>org.seaborne.rdf-delta</groupId>
@@ -111,6 +116,13 @@ index 3c5de6f0..ce90c1c3 100644
        <version>2.0.0-SNAPSHOT</version>
      </dependency>
 
+     <dependency>
+       <groupId>org.apache.jena</groupId>
+-      <artifactId>jena-fuseki-main</artifactId>
++      <artifactId>jena-fuseki-server</artifactId>
+     </dependency>
+
+     <dependency>
 @@ -53,6 +53,12 @@
        <scope>test</scope>
      </dependency>

--- a/patches/enable-geosparql.diff
+++ b/patches/enable-geosparql.diff
@@ -1,61 +1,20 @@
 diff --git a/rdf-delta-fuseki-server/pom.xml b/rdf-delta-fuseki-server/pom.xml
-index ddbd0a15..f1dc71c8 100644
+index ddbd0a15..ec5bf83e 100644
 --- a/rdf-delta-fuseki-server/pom.xml
 +++ b/rdf-delta-fuseki-server/pom.xml
-@@ -3,15 +3,15 @@
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
--
-+
-        http://www.apache.org/licenses/LICENSE-2.0
--
-+
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--
-+
-    See the NOTICE file distributed with this work for additional
-    information regarding copyright ownership.
- -->
-@@ -28,7 +28,7 @@
-     <groupId>org.seaborne.rdf-delta</groupId>
-     <artifactId>rdf-delta</artifactId>
-     <version>2.0.0-SNAPSHOT</version>
--  </parent>
-+  </parent>
-
-   <properties>
-     <automatic.module.name>org.seaborne.rdf_delta.fuseki_server</automatic.module.name>
-@@ -40,17 +40,17 @@
-       <groupId>org.seaborne.rdf-delta</groupId>
-       <artifactId>rdf-delta-fuseki</artifactId>
-       <version>2.0.0-SNAPSHOT</version>
--    </dependency>
--
-+    </dependency>
-+
-     <dependency>
-       <groupId>org.seaborne.rdf-delta</groupId>
-       <artifactId>rdf-delta-client</artifactId>
-       <version>2.0.0-SNAPSHOT</version>
--    </dependency>
-+    </dependency>
-
+@@ -50,7 +50,7 @@
+ 
      <dependency>
        <groupId>org.apache.jena</groupId>
 -      <artifactId>jena-fuseki-main</artifactId>
 +      <artifactId>jena-fuseki-server</artifactId>
      </dependency>
-
+ 
      <dependency>
 @@ -64,6 +64,13 @@
        <artifactId>jena-text</artifactId>
      </dependency>
-
+ 
 +
 +    <dependency>
 +      <groupId>org.apache.jena</groupId>
@@ -64,75 +23,5 @@ index ddbd0a15..f1dc71c8 100644
 +    </dependency>
 +
    </dependencies>
-
+ 
    <build>
-@@ -94,7 +101,7 @@
-           </execution>
-         </executions>
-       </plugin>
--
-+
-       <!-- Shaded uber jar -->
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-diff --git a/rdf-delta-fuseki/pom.xml b/rdf-delta-fuseki/pom.xml
-index 3c5de6f0..fbad3da2 100644
---- a/rdf-delta-fuseki/pom.xml
-+++ b/rdf-delta-fuseki/pom.xml
-@@ -3,15 +3,15 @@
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
--
-+
-        http://www.apache.org/licenses/LICENSE-2.0
--
-+
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--
-+
-    See the NOTICE file distributed with this work for additional
-    information regarding copyright ownership.
- -->
-@@ -28,7 +28,7 @@
-     <groupId>org.seaborne.rdf-delta</groupId>
-     <artifactId>rdf-delta</artifactId>
-     <version>2.0.0-SNAPSHOT</version>
--  </parent>
-+  </parent>
-
-   <properties>
-     <automatic.module.name>org.seaborne.rdf_delta.fuseki</automatic.module.name>
-@@ -38,13 +38,13 @@
-
-     <dependency>
-       <groupId>org.seaborne.rdf-delta</groupId>
--      <artifactId>rdf-delta-client</artifactId>
-+      <artifactId>rdf-delta-client</artifactId>
-       <version>2.0.0-SNAPSHOT</version>
-     </dependency>
-
-     <dependency>
-       <groupId>org.apache.jena</groupId>
--      <artifactId>jena-fuseki-main</artifactId>
-+      <artifactId>jena-fuseki-server</artifactId>
-     </dependency>
-
-     <dependency>
-@@ -53,6 +53,12 @@
-       <scope>test</scope>
-     </dependency>
-
-+    <dependency>
-+      <groupId>org.apache.jena</groupId>
-+      <artifactId>jena-geosparql</artifactId>
-+      <version>5.4.0</version>
-+    </dependency>
-+
-   </dependencies>
-
- </project>

--- a/patches/enable-geosparql.diff
+++ b/patches/enable-geosparql.diff
@@ -55,7 +55,7 @@ index ddbd0a15..76857451 100644
 +    <dependency>
 +      <groupId>org.apache.jena</groupId>
 +      <artifactId>jena-geosparql</artifactId>
-+      <version>5.5.0</version>
++      <version>5.4.0</version>
 +    </dependency>
 +
    </dependencies>
@@ -118,7 +118,7 @@ index 3c5de6f0..ce90c1c3 100644
 +    <dependency>
 +      <groupId>org.apache.jena</groupId>
 +      <artifactId>jena-geosparql</artifactId>
-+      <version>5.5.0</version>
++      <version>5.4.0</version>
 +    </dependency>
 +
    </dependencies>

--- a/patches/rocksdb.diff
+++ b/patches/rocksdb.diff
@@ -1,0 +1,26 @@
+diff --git a/pom.xml b/pom.xml
+index 3538a840..3df5db07 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -210,7 +210,7 @@
+         <groupId>org.rocksdb</groupId>
+         <artifactId>rocksdbjni</artifactId>
+         <version>${ver.rocksdb}</version>
+-        <classifier>linux64</classifier>
++        <classifier>linux64-musl</classifier>
+       </dependency>
+ 
+       <dependency>
+diff --git a/rdf-delta-server-local/pom.xml b/rdf-delta-server-local/pom.xml
+index d4e1716d..9317dbfb 100644
+--- a/rdf-delta-server-local/pom.xml
++++ b/rdf-delta-server-local/pom.xml
+@@ -49,7 +49,7 @@
+     <dependency>
+       <groupId>org.rocksdb</groupId>
+       <artifactId>rocksdbjni</artifactId>
+-      <classifier>linux64</classifier>
++      <classifier>linux64-musl</classifier>
+     </dependency>
+     
+     <!-- Require a logging implementation for tests -->

--- a/query.py
+++ b/query.py
@@ -1,0 +1,58 @@
+"""query.py
+
+Submit some test queries to the fuseki servers
+
+"""
+
+from itertools import product
+
+import httpx
+
+fuseki1 = "http://localhost:3030/ds"
+fuseki2 = "http://localhost:3031/ds"
+
+basic_query = """
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+SELECT *
+WHERE {
+  ?s a geo:Feature .
+  ?s ?p ?o .
+}
+LIMIT 5
+"""
+
+geosparql_query = """
+PREFIX addr:    <https://linked.data.gov.au/def/addr/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+
+SELECT DISTINCT ?address
+WHERE {
+  ?address a addr:Address .
+  <https://example.org/australia> geo:sfContains ?address .
+}
+LIMIT 5
+"""
+
+text_query = """
+PREFIX text: <http://jena.apache.org/text#>
+
+SELECT *
+WHERE {
+    ?uri text:query "queensland" .
+}
+LIMIT 5
+"""
+
+queries = (basic_query, geosparql_query, text_query)
+servers = (fuseki1, fuseki2)
+
+combinations = product(servers, queries)
+
+headers = {"Content-Type": "application/sparql-query", "Accept": "text/csv"}
+
+for server, query in combinations:
+    client = httpx.Client()
+    response = client.post(server, content=query, headers=headers)
+    response.raise_for_status()
+    print(response.content.decode())

--- a/query.py
+++ b/query.py
@@ -44,7 +44,23 @@ WHERE {
 LIMIT 5
 """
 
-queries = (basic_query, geosparql_query, text_query)
+text_and_geosparql_query = """
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX text: <http://jena.apache.org/text#>
+
+SELECT DISTINCT ?address ?literal
+WHERE {
+  BIND("POLYGON ((152.685242 -27.161808, 152.698975 -27.829361, 153.492737 -27.829361, 153.435059 -27.178912, 152.685242 -27.161808))"^^geo:wktLiteral AS ?polygon)
+  ?address geo:hasGeometry / geo:asWKT ?point ;
+           rdfs:label ?addressLabel .
+  FILTER(geof:sfWithin(?point, ?polygon))
+  (?address ?score ?literal) text:query ( "Drive" "highlight:" ) .
+}
+"""
+
+queries = (basic_query, geosparql_query, text_query, text_and_geosparql_query)
 servers = (fuseki1, fuseki2)
 
 combinations = product(servers, queries)


### PR DESCRIPTION
Added a dependency patch to switch to rdf-delta-fuseki-server instead of rdf-delta-fuseki-main and enable GeoSPARQL.

You will have to rebuild the images with docker compose up -d --build
Best to start with a clean instance, so delete any fuseki data and run task load after you've rebuilt the image. 

After that this query should work: https://github.com/Kurrawong/rdf-delta-container-image/tree/enable-geosparql?tab=readme-ov-file#querying-the-fuseki-instances-with-sparql

This change only works with an older version of rdf-delta (pre-1.3.0-SNAPSHOT), which still has some vulnerabilities that need to be addressed. As soon as the new release is stable, we need to update the Dockerfile to build the newer version instead.